### PR TITLE
Update cachetools dependency

### DIFF
--- a/endpoints_management/__init__.py
+++ b/endpoints_management/__init__.py
@@ -18,7 +18,7 @@ import logging
 
 from . import auth, config, control, gen
 
-__version__ = '1.11.0'
+__version__ = '1.11.0+lumapps1'
 
 _logger = logging.getLogger(__name__)
 _logger.setLevel(logging.INFO)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 backoff>=1.6.0
-cachetools>=1.0.0,<2
+cachetools>=1.0.0,<4
 dogpile.cache>=0.6.1,<0.7
 enum34>=1.1.6,<2
 google-apitools>=0.5.21,<0.6

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ with open('endpoints_management/__init__.py', 'r') as f:
 
 install_requires = [
     'backoff>=1.6.0',
-    'cachetools>=1.0.0,<2',
+    'cachetools>=1.0.0,<4',
     "dogpile.cache>=0.6.1,<0.7",
     'enum34>=1.1.6,<2',
     'google-apitools>=0.5.21,<0.6',


### PR DESCRIPTION
Fixes incompatibility with some of the other google-cloud package, see also:
- https://github.com/cloudendpoints/endpoints-management-python/issues/72
- https://github.com/cloudendpoints/endpoints-management-python/pull/84